### PR TITLE
use pointer when load ffm model and release model with Explicit method 

### DIFF
--- a/ffm.h
+++ b/ffm.h
@@ -24,7 +24,8 @@ struct ffm_model {
     ffm_int k; // number of latent factors
     ffm_float *W = nullptr;
     bool normalization;
-    ~ffm_model();
+    //~ffm_model();
+    void release();
 };
 
 struct ffm_parameter {
@@ -41,6 +42,8 @@ void ffm_read_problem_to_disk(string txt_path, string bin_path);
 void ffm_save_model(ffm_model &model, string path);
 
 ffm_model ffm_load_model(string path);
+
+ffm_model* ffm_load_model_ptr(string path);
 
 ffm_model ffm_train_on_disk(string Tr_path, string Va_path, ffm_parameter param);
 


### PR DESCRIPTION
1.  Release model(W) not in destructor method.
2. Not to use ffm_load_model, because this method return a object which is local variables, when it returned, it will call destructor(~ffm_model()), and W will be freed.
3. Add a new method(ffm_load_model_ptr) which return a pointer to the model.
4. Add a new class method of ffm_model--release, which is used to free model in explicit way.