### PR TITLE
Automatically use SSE when available

### DIFF
--- a/ffm.cpp
+++ b/ffm.cpp
@@ -34,6 +34,10 @@ v: Value of each element in the problem
 #include <cassert>
 #include <numeric>
 
+#if defined __SSE3__
+#define USESSE 1
+#endif
+
 #if defined USESSE
 #include <pmmintrin.h>
 #endif


### PR DESCRIPTION
This PR allows LIBFFM to automatically use SSE3 (which `pmmintrin.h` requires) without the need for `-DUSESSE`.

Modern compilers define `__SSE3__` based on `-m` flags (like `-march`).

https://stackoverflow.com/questions/28939652/how-to-detect-sse-sse2-avx-avx2-avx-512-avx-128-fma-kcvi-availability-at-compile